### PR TITLE
Fix bug Configuration#merge

### DIFF
--- a/lib/carthage_cache/configuration.rb
+++ b/lib/carthage_cache/configuration.rb
@@ -81,7 +81,7 @@ module CarthageCache
       end
 
       @hash_object = hash_object.merge(other_hash) do |key, oldval, newval|
-        if oldval.is_a?(Hash) then oldval.merge(newval) end
+        oldval.is_a?(Hash) ? oldval.merge(newval) : newval
       end
       self
     end

--- a/spec/carthage_cache/configuration_spec.rb
+++ b/spec/carthage_cache/configuration_spec.rb
@@ -31,5 +31,15 @@ describe CarthageCache::Configuration do
       main_config.merge(other_config)
       expect(main_config.hash_object).to eq(expected_hash)
     end
+
+    it 'merges keys from another configuration object having same key into this one correctly' do
+      expected_hash = { :foo=>"new value" }
+      other_config = CarthageCache::Configuration.new
+      other_config.hash_object[:foo] = "new value"
+      main_config = CarthageCache::Configuration.new
+      main_config.hash_object[:foo] = "old value"
+      main_config.merge(other_config)
+      expect(main_config.hash_object).to eq(expected_hash)
+    end
   end
 end


### PR DESCRIPTION
There is a bug in `Configuration#merge`.
Hash value becomes nil when merging object has the same key.
