### PR TITLE
Fix small typo

### DIFF
--- a/lib/carthage_cache/project.rb
+++ b/lib/carthage_cache/project.rb
@@ -49,7 +49,7 @@ module CarthageCache
     private
 
       def cartfile_resolved_path
-        @carfile_resolved_path ||= File.join(project_path, "Cartfile.resolved")
+        @cartfile_resolved_path ||= File.join(project_path, "Cartfile.resolved")
       end
 
       def create_tmpdir


### PR DESCRIPTION
Fixes a small typo in `project.rb`, going from `carfile` -> `cartfile`