### PR TITLE
Cache .version files

### DIFF
--- a/lib/carthage_cache/archive_builder.rb
+++ b/lib/carthage_cache/archive_builder.rb
@@ -35,7 +35,10 @@ module CarthageCache
         filter_block = nil
         if platforms
           filter_block = ->(file) do
-            lock_file?(file) || platforms.map(&:downcase).include?(file.downcase)
+            next(true) if lock_file?(file)
+            next(true) if version_file?(file)
+            next(true) if platforms.map(&:downcase).include?(file.downcase)
+            next(false)
           end
         end
 
@@ -50,6 +53,10 @@ module CarthageCache
 
       def lock_file?(file)
         file == CarthageCacheLock::LOCK_FILE_NAME
+      end
+
+      def version_file?(file)
+        File.extname(file) == ".version"
       end
 
   end

--- a/lib/carthage_cache/archiver.rb
+++ b/lib/carthage_cache/archiver.rb
@@ -9,7 +9,7 @@ module CarthageCache
     end
 
     def archive(archive_path, destination_path, &filter_block)
-      files = Dir.entries(archive_path).select { |x| !x.start_with?(".") }
+      files = Dir.entries(archive_path).select { |file| !hidden_file?(file) || version_file?(file) }
       files = files.select(&filter_block) if filter_block
       files = files.sort_by(&:downcase)
       executor.execute("cd #{archive_path} && zip -r -X #{File.expand_path(destination_path)} #{files.join(' ')} > /dev/null")
@@ -18,6 +18,16 @@ module CarthageCache
     def unarchive(archive_path, destination_path)
       executor.execute("unzip -o #{archive_path} -d #{destination_path} > /dev/null")
     end
+
+    private
+
+      def hidden_file?(file)
+        file.start_with?(".")
+      end
+
+      def version_file?(file)
+        file.end_with?(".version")
+      end
 
   end
 

--- a/lib/carthage_cache/archiver.rb
+++ b/lib/carthage_cache/archiver.rb
@@ -9,7 +9,11 @@ module CarthageCache
     end
 
     def archive(archive_path, destination_path, &filter_block)
-      files = Dir.entries(archive_path).select { |file| !hidden_file?(file) || version_file?(file) }
+      files = Dir.entries(archive_path).select do |f|
+        next(true) if version_file?(f)
+        next(true) unless hidden_file?(f)
+        next(false)
+      end
       files = files.select(&filter_block) if filter_block
       files = files.sort_by(&:downcase)
       executor.execute("cd #{archive_path} && zip -r -X #{File.expand_path(destination_path)} #{files.join(' ')} > /dev/null")
@@ -26,7 +30,7 @@ module CarthageCache
       end
 
       def version_file?(file)
-        file.end_with?(".version")
+        File.extname(file) == ".version"
       end
 
   end


### PR DESCRIPTION
`.version` files can be useful in scripts confirming commitish values of current carthage build directory, like in this [carthage-verify script](https://github.com/Carthage/workflows/blob/master/carthage-verify). This PR makes the change to include `.version` files in the published cache.